### PR TITLE
Makes it possible for Ainur's code to create a new month with the user's specified goal

### DIFF
--- a/MadMoney/MadMoney/App.xaml.cs
+++ b/MadMoney/MadMoney/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MadMoney.Model;
+using System;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -6,6 +7,9 @@ namespace MadMoney
 {
     public partial class App : Application
     {
+        // Global budget instance
+        public static Budget GlobalBudget;
+
         public App()
         {
             InitializeComponent();

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -15,16 +15,15 @@ namespace MadMoney
     [DesignTimeVisible(false)]
     public partial class MainBudgetSummaryPage : ContentPage
     {
-        //private IEnumerable<Expense> expenseCollection;
 
         public MainBudgetSummaryPage()
         {
             //expenseCollection = MainPageTestManager.GetTestMonth().Expenses;
 
-
             BindingContext = MainPageTestManager.GetTestMonth();
 
             InitializeComponent();
+
 
 
         }

--- a/MadMoney/MadMoney/Model/Budget.cs
+++ b/MadMoney/MadMoney/Model/Budget.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace MadMoney.Model
 {
-    // Not static or singleton as it may make sense in the future
+    // Not static or singleton as it may make sense in the (hypothetical) future
     // to have more than one Budget (that is, set of BudgetMonths)
     public class Budget
     {
@@ -14,19 +14,36 @@ namespace MadMoney.Model
             budgetMonths = new List<BudgetMonth>();
         }
 
+        // TODO:
+        //BudgetMonth class type is best as an implementation detail of the Model
         public IEnumerable<BudgetMonth> BudgetMonths
         { get { return budgetMonths; } }
         // may need to provide additional ways to access/modify BudgetMonths collection
 
-        public void AddBudgetMonth(BudgetMonth budget)
+        public void CreateNewMonth(decimal goal, DateTime monthAndYear)
         {
-            budgetMonths.Add(budget);
+            budgetMonths.Add(new BudgetMonth(goal, monthAndYear));
+            // Budget should not expose the BudgetMonth type at all
+            // BudgetMonth is a class type that is internal to the implementation
+            // of the model
+
+            // TODO:
+            // Budget must enforce that no more than one BudgetMonth
+            // exists for any one calendar month
         }
-        // Budgets must enforce that no more than one BudgetMonth
-        // exists for any one calendar month
-        
+
+
         // The design doesn't provide for deleting a budget month
         // public void DeleteBudget(DateTime month) { }
-        
+
+
+        // ask budget, here, give me all of the expenses for this budget month
+
+        // ask the model, hey, give me the budget for this month
+        // hey, give me the expenses for this month
+        // things that are calculated (instead of stored) should be handled in
+        // the viewmodel rather than in the model
+        // viewmodels will likely implement thier own  (or possibly utility classes
+        // shared between viewmodels) 
     }
 }

--- a/MadMoney/MadMoney/Model/BudgetMonth.cs
+++ b/MadMoney/MadMoney/Model/BudgetMonth.cs
@@ -6,10 +6,8 @@ using System.Text;
 
 namespace MadMoney.Model
 {
-    // Baseline default implementation
-    public class BudgetMonth : INotifyPropertyChanged // ***TODO: Finish implementing this interface
-    // May ultimately be unnnecessary as an Expense may not
-    // change while it is bound to a UI control
+    public class BudgetMonth : INotifyPropertyChanged // ** TODO: Finish implementing this interface
+    // OR...May ultimately be unnnecessary
     // Bindings are re-established each time a Page is loaded, correct?
     // Following this guide for INotifyPropertyChanged:
     // https://docs.microsoft.com/en-us/dotnet/framework/winforms/controls/raise-change-notifications--bindingsource
@@ -42,11 +40,11 @@ namespace MadMoney.Model
 
         // Which constructors are desired?
         public BudgetMonth(decimal goal,
-                           DateTime date)
+                           DateTime monthAndYear)
         {
             expenseCollection = new List<Expense>();
             BudgetGoal = goal;
-            StartDate = date;
+            MonthAndYear = monthAndYear;
         }
         // the StartDate of the month can only be set as the
         // BudgetMonth is constructed
@@ -62,15 +60,27 @@ namespace MadMoney.Model
         }
         // Expense can go over budget goal
 
+
+
+        // TODO: Move AmountRemainingInBudgetGoal and any other methods
+        // that calculate and return 
+        // if it's not data that the Model stores, then it is something you calculate
+        // That calculation is business logic and belongs in the ViewModel
+        public decimal AmountRemainingInBudgetGoal { get; }
         // If AmountRemainingInBudgetGoal > 0, user has budget left this month
         // If AmountRemainingInBudgetGoal == 0, user has used up budget exactly
         // If AmountRemainingInBudgetGoal < 0, user has exceeded budget
-        public decimal AmountRemainingInBudgetGoal { get; }
 
-        // ??? A BudgetMonth's StartDate (that is the first of the month)
-        // Cannot be modified by users after the BudgetMonth is created
-        public DateTime StartDate { get; }
-        // explore using a different type for this?
+        // TODO:
+        // Any date in a month is valid input
+        // However, unlike Expense, extra data (that is: day, hour, minute, second)
+        // is truncated as it has no reasonable use.
+        // Specifically, MonthAndYear represents the duration of one month in a year
+        // rather than a specific point in the year
+        public DateTime MonthAndYear { get; }
+        
+
+
 
         public IEnumerable<Expense> Expenses {
             get { return expenseCollection; }
@@ -84,11 +94,11 @@ namespace MadMoney.Model
             expenseCollection.Add(exp);
         }
 
-        public void EditExpense(Guid guid) { }
+        public void EditExpense(string id) { }
         // How to specify which Expense to edit?
         // How to submit those edits?
 
-        public void DeleteExpense(Guid guid) { }
+        public void DeleteExpense(string id) { }
         // How to specify which Expense to delete?
 
 

--- a/MadMoney/MadMoney/Model/Expense.cs
+++ b/MadMoney/MadMoney/Model/Expense.cs
@@ -5,6 +5,20 @@ using System.Text;
 
 namespace MadMoney.Model
 {
+    // ? Write a proposal for this class
+  
+    //public class ExpenseCategory2
+    //{
+    //    public char Emoji { get; set; }
+    //    public string Name { get; set; }
+    //}
+
+    
+    // TODO (Lynn):
+    // ExpenseCategory more appropriately its own class type
+    // rather than just an enum.
+    // to contain the emoji that corresponds to each category
+    // as well as the string the corresponds to each category
     public enum ExpenseCategory
     { 
         Groceries,
@@ -15,49 +29,111 @@ namespace MadMoney.Model
         TreatYoSelf
     }
 
-    // Baseline default implementation
-    public class Expense // : INotifyPropertyChanged
-        // None of my test data changes Expenses yet
-        // May ultimately be unnnecessary as an Expense may not
-        // change while it is bound to a UI control
+    public class Expense // : INotifyPropertyChanged <- May not need this
+        // May ultimately be unnnecessary as I don't think that an Expense
+        // can change while a page is loaded (rather between pages)
         // Bindings are re-established each time a Page is loaded, correct?
     {
-        // Which constructors are desired?
+        /// <summary>
+        /// Constructor for new created Expenses.
+        /// </summary>
+        /// <param name="descrip"></param>
+        /// <param name="amt"></param>
+        /// <param name="date"></param>
+        /// <param name="cat"></param>
         public Expense(string descrip,
                        decimal amt,
                        DateTime date,
                        ExpenseCategory cat)
         {
-            Guid = Guid.NewGuid();
+            _id = Guid.NewGuid();
             Description = descrip;
             Amount = amt;
             Date = date;
             Category = cat;
         }
-        public Guid Guid { get; }
-        // Immutable after construction
+        /// <summary>
+        /// Constructor for Expenses deserialized from file.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="descrip"></param>
+        /// <param name="amt"></param>
+        /// <param name="date"></param>
+        /// <param name="cat"></param>
+        public Expense(string id,
+                       string descrip,
+                       decimal amt,
+                       DateTime date,
+                       ExpenseCategory cat)
+        {
+            _id = new Guid(id);
+            Description = descrip;
+            Amount = amt;
+            Date = date;
+            Category = cat;
+        }
+
+        /// <summary>
+        /// Data field that backs Id property
+        /// </summary>
+        private Guid _id;
+
+        /// <summary>
+        /// Unique identifier for the Expense.
+        /// Example: 0f8fad5b-d9cb-469f-a165-70867728950e
+        /// </summary>
+        // Immutable after construction / deserialization from disk
+        public string Id
+        {
+            get { return _id.ToString(); }
+        }
+
+        /// <summary>
+        /// Name that describes the Expense.
+        /// Example: "Trader Joe's"
+        /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// Amount of the Expense in USD dollars and cents.
+        /// Example: $42.50
+        /// </summary>
         public decimal Amount { get; set; }
+        // TODO: ViewModel(s) to validate user input before constructing an
+        // Expense (two decimal places)
+        // Could be put in a shared utility class for the Set Goal, Add Expense
+        // and Edit Expense pages.
+        // Or, both Ainur and Andrea could implement it independently for practice.
+        // Also support (but don't require) comma seperators
+        // Either way works for Brillan.
+
+        /// <summary>
+        /// Year, month and day of the Expense.
+        /// Example: 2020-02-01 (February 1, 2020)
+        /// Note: Time (hour, minute, second) is accepted and stored for
+        /// future use.
+        /// </summary>
         public DateTime Date { get; set; }
+
+
+        /// <summary>
+        /// Category of the Expense. (Currently of ExpenseCategory enum type.)
+        /// Example: Groceries
+        /// </summary>
+        // TODO: Needs to be updated to be of the type of the enum class wrapper type
+        // that Lynn is working on this as a part of Filter Expenses page development
+        // This new class type to get its own cs file, correct?
         public ExpenseCategory Category { get; set; }
 
 
-
-        public bool IsValidAmount() { return true; }
-        // need more user input validation methods
-
-
-        // complete properties on Expense class
-
-
-        // View should ask ViewModel to ask Model about
-        // what is valid for each of these properties, correct?
-        // Not the View's job to make this decision
-        // It's the Model's job to know what is valid
-        // Seems relevant to put these methods on the Model
-        // class directly, versus in a helper class
-        // Maybe as a nested/inner class?
-
-
+        // ** NOTE:
+        // Shift in advice about where data validation logic belongs
+        // I think that I may have misunderstood this before
+        // it's business logic data, so it belongs in the ViewModel(s)
+        // Model's job to implement the in-memory data store
+        // Subjective whether file i/o class should be interacted with
+        // by the ViewModel or the Model
+        // Pros and cons for each
+        // TODO: Ask Kal/TAs
     }
 }

--- a/MadMoney/MadMoney/ViewModel/MainPageTestManager.cs
+++ b/MadMoney/MadMoney/ViewModel/MainPageTestManager.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using MadMoney;
+using System.Linq;
 
 namespace MadMoney.ViewModel
 {
@@ -10,31 +12,30 @@ namespace MadMoney.ViewModel
     // Creates a dummy BudgetMonth so that the UI can bind to it
     public static class MainPageTestManager
     {
-
-
-        private static BudgetMonth february =
-             new BudgetMonth(2000M, DateTime.Parse("2020-02-01"));
-
         public static BudgetMonth GetTestMonth()
         {
-            february.AddExpense(
+            App.GlobalBudget.CreateNewMonth(2000M,
+                                            DateTime.Parse("2020-02-01"));
+
+            App.GlobalBudget.BudgetMonths.ToArray()[0].AddExpense(
                 new Expense("Trader Joe's",
                             42.50M,
                             DateTime.Parse("2020-02-01"),
                             ExpenseCategory.Groceries));
-            february.AddExpense(
+
+            App.GlobalBudget.BudgetMonths.ToArray()[0].AddExpense(
                 new Expense("Amazon.com",
                             125.37M,
                             DateTime.Parse("2020-02-13"),
                             ExpenseCategory.TreatYoSelf));
 
-            return february;
+            return App.GlobalBudget.BudgetMonths.ToArray()[0];
         }
 
 
         public static void UpdateGoal(decimal newGoal)
         {
-            february.BudgetGoal = newGoal;
+            App.GlobalBudget.BudgetMonths.ToArray()[0].BudgetGoal = newGoal;
         }
 
     }


### PR DESCRIPTION
Example call on GlobalBudget object to create the budget for February 2020 with a goal of $2,000:
App.GlobalBudget.CreateNewMonth(2000M, DateTime.Parse("2020-02-01"));

Note that it is the caller's job to make sure that the goal is valid (that is, a decimal value that is zero or greater)
It is also the caller's job to specify which month and year the budget is for in the form of a DateTime object.

Commit comments:
In Budget, changed AddBudgetMonth to CreateNewMonth, eventually hoping for BudgetMonth to be a class type internal to the implementation of the Model (but the current data binding prevents this)
In BudgetMonth, clarified that the DateTime property encodes the month and year of the expense
Also updated for better use of guids
Updated Expense class to more elegantly use guids (keeping in mind that these will be serialized and deserialized)
Created GlobalBudget instance in App
Adapted MainPageTestManager to reference the GlobalBudget object instead of a dummy BudgetMonth