### PR TITLE
Highlights: Added CurrentlyDisplayedMonthYear, AddExpense, GetBudgetGoalByMonthYear

### DIFF
--- a/MadMoney/MadMoney/App.xaml.cs
+++ b/MadMoney/MadMoney/App.xaml.cs
@@ -16,6 +16,9 @@ namespace MadMoney
         {
             InitializeComponent();
 
+            App.GlobalBudget.CreateNewMonth(2000M,
+                                DateTime.Parse("2020-03-01"));
+
             MainPage = new MainBudgetSummaryPage();
         }
 

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
@@ -74,7 +74,8 @@
             <Button x:Name="AddExpenseButton_Top"
                 Text="Add Expense"
                 FontSize="22"
-                BackgroundColor="LightGreen"/>
+                BackgroundColor="LightGreen"
+                Pressed="AddExpenseButton_Top_Pressed"/>
 
             <!-- TODO: Fix this empty Label hack for 
                                 I can't figure out how else to do the left
@@ -84,7 +85,8 @@
             <Button x:Name="FilterExpensesButton"
                 Text="Filter Expenses"
                 FontSize="22"
-                BackgroundColor="LightBlue"/>
+                BackgroundColor="LightBlue"
+                Pressed="FilterExpensesButton_Pressed"/>
         </StackLayout>
 
 

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -13,10 +13,22 @@ namespace MadMoney
     [DesignTimeVisible(false)]
     public partial class MainBudgetSummaryPage : ContentPage
     {
-
         public MainBudgetSummaryPage()
         {
-            BindingContext = MainPageTestManager.GetTestMonth();
+            App.GlobalBudget.AddExpense("Amazon.com",
+                            125.37M,
+                            DateTime.Parse("2020-03-13"),
+                            ExpenseCategory.TreatYoSelf);
+
+
+            App.GlobalBudget.AddExpense("Trader Joe's",
+                            42.50M,
+                            DateTime.Parse("2020-03-01"),
+                            ExpenseCategory.Groceries);
+
+
+            BindingContext = App.GlobalBudget.GetBudgetMonthByMonthYear(
+                                    App.GlobalViewData.CurrentlyDisplayedMonthYear);
 
             InitializeComponent();
 
@@ -53,6 +65,16 @@ namespace MadMoney
         {
             MainPageTestManager.UpdateGoal(MainPageTestManager.GetTestMonth().BudgetGoal + 100);
             return;
+        }
+
+        private void AddExpenseButton_Top_Pressed(object sender, EventArgs e)
+        {
+
+        }
+
+        private void FilterExpensesButton_Pressed(object sender, EventArgs e)
+        {
+
         }
     }
 }

--- a/MadMoney/MadMoney/Model/Budget.cs
+++ b/MadMoney/MadMoney/Model/Budget.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using MadMoney.Utility;
 
 namespace MadMoney.Model
 {
@@ -20,24 +21,66 @@ namespace MadMoney.Model
         { get { return budgetMonths; } }
         // may need to provide additional ways to access/modify BudgetMonths collection
 
-        public void CreateNewMonth(decimal goal, DateTime monthAndYear)
+        public void CreateNewMonth(decimal goal, DateTime monthYear)
         {
-            budgetMonths.Add(new BudgetMonth(goal, monthAndYear));
-            // Budget should not expose the BudgetMonth type at all
-            // BudgetMonth is a class type that is internal to the implementation
-            // of the model
+            // If it is a duplicate month, throw
+            if (budgetMonths.Exists(month =>
+                DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear)))
+            {
+                throw new ArgumentException($"Budget already exists for {monthYear.ToString()}. Cannot add a duplicate budget month.");
+            }
 
-            // TODO:
-            // Budget must enforce that no more than one BudgetMonth
-            // exists for any one calendar month
+
+            // Idea: Add the new month to the beginning of the list?
+            // it is probably the month that is most likely to be accessed
+            // We'd need to switch data structure for that to be a good idea:
+            // https://stackoverflow.com/questions/705969/adding-object-to-the-beginning-of-generic-listt
+
+
+            budgetMonths.Add(new BudgetMonth(goal, monthYear));
+            // Ideally Budget would not expose the BudgetMonth type at all
+            // BudgetMonth is a class type that is internal to the implementation
+            // of the model, but for now it is exposed
         }
 
-        public void AddExpense(string descrip,
-                       decimal amt,
-                       DateTime date,
-                       ExpenseCategory cat)
+
+        public BudgetMonth GetBudgetMonthByMonthYear(DateTime monthYear)
         {
-            budgetMonths[0].AddExpense(new Expense(descrip, amt, date, cat));
+            return budgetMonths.Find(month =>
+                    DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear));
+        }
+
+        public decimal GetBudgetGoalByMonthYear(DateTime monthYear)
+        {
+            return budgetMonths.Find(month =>
+                DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear)).BudgetGoal;
+        }
+
+        public void AddExpense(string expDescrip,
+                               decimal expAmt,
+                               DateTime expDate,
+                               ExpenseCategory expCat)
+        {
+
+            // Step through the list of months
+            // Find the month for which to add the expense
+            var budgetMonthOfExpense = budgetMonths.Find(month =>
+                DateTimeUtility.IsSameMonthYear(month.MonthYear, expDate));
+
+
+            // If the month is not found, create the new month
+            if (budgetMonthOfExpense == null)
+            {
+                // TODO: LOOK UP WHAT THE GOAL SHOULD BE FOR A NEW MONTH THAT IS CREATED FROM ADD EXPENSE
+                budgetMonths.Add(new BudgetMonth(
+                        999999M, DateTimeUtility.TruncateToMonthYear(expDate)));
+
+                budgetMonthOfExpense = budgetMonths.Find(month =>
+                    DateTimeUtility.IsSameMonthYear(month.MonthYear, expDate));
+            }
+
+
+            budgetMonthOfExpense.AddExpense(new Expense(expDescrip, expAmt, expDate, expCat));
 
         }
 

--- a/MadMoney/MadMoney/Model/BudgetMonth.cs
+++ b/MadMoney/MadMoney/Model/BudgetMonth.cs
@@ -40,11 +40,11 @@ namespace MadMoney.Model
 
         // Which constructors are desired?
         public BudgetMonth(decimal goal,
-                           DateTime monthAndYear)
+                           DateTime monthYear)
         {
             expenseCollection = new List<Expense>();
             BudgetGoal = goal;
-            MonthAndYear = monthAndYear;
+            MonthYear = monthYear;
         }
         // the StartDate of the month can only be set as the
         // BudgetMonth is constructed
@@ -74,9 +74,9 @@ namespace MadMoney.Model
         // Any date in a month is valid input
         // However, unlike Expense, extra data (that is: day, hour, minute, second)
         // is truncated as it has no reasonable use.
-        // Specifically, MonthAndYear represents the duration of one month in a year
+        // Specifically, MonthYear represents the duration of one month in a year
         // rather than a specific point in the year
-        public DateTime MonthAndYear { get; }
+        public DateTime MonthYear { get; }
         
 
 

--- a/MadMoney/MadMoney/Utility/DateTimeUtility.cs
+++ b/MadMoney/MadMoney/Utility/DateTimeUtility.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MadMoney.Utility
+{
+    public static class DateTimeUtility
+    {
+        public static DateTime TruncateToMonthYear(DateTime date)
+        {
+            return new DateTime(date.Year, date.Month, 1);
+            // Interested to try what happens when set the day-of-month to zero
+        }
+
+        public static bool IsSameMonthYear(DateTime date1, DateTime date2)
+        {
+            return (date1.Year == date2.Year) && (date1.Month == date2.Month);
+        }
+
+    }
+}

--- a/MadMoney/MadMoney/View/ViewData.cs
+++ b/MadMoney/MadMoney/View/ViewData.cs
@@ -1,12 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using MadMoney.Utility;
 
 namespace MadMoney.View
 {
     public class ViewData
     {
-        public DateTime CurrentlyDisplayedMonth { get; set; }
+        // When the app starts, set the currently displayed month
+        // Discard partial data, set the DateTime to be the first of the month.
+        // Day-of-the month has no meaning, so best to have it be the same
+        // for all of them.
+        public ViewData()
+        {
+            CurrentlyDisplayedMonthYear = DateTimeUtility.TruncateToMonthYear(DateTime.Today);
+        }
+
+        public DateTime CurrentlyDisplayedMonthYear { get; set; }
 
     }
 }

--- a/MadMoney/MadMoney/ViewModel/MainPageTestManager.cs
+++ b/MadMoney/MadMoney/ViewModel/MainPageTestManager.cs
@@ -14,20 +14,10 @@ namespace MadMoney.ViewModel
     {
         public static BudgetMonth GetTestMonth()
         {
-            App.GlobalBudget.CreateNewMonth(2000M,
-                                            DateTime.Parse("2020-02-01"));
 
-            App.GlobalBudget.BudgetMonths.ToArray()[0].AddExpense(
-                new Expense("Trader Joe's",
-                            42.50M,
-                            DateTime.Parse("2020-02-01"),
-                            ExpenseCategory.Groceries));
 
-            App.GlobalBudget.BudgetMonths.ToArray()[0].AddExpense(
-                new Expense("Amazon.com",
-                            125.37M,
-                            DateTime.Parse("2020-02-13"),
-                            ExpenseCategory.TreatYoSelf));
+
+
 
             return App.GlobalBudget.BudgetMonths.ToArray()[0];
         }


### PR DESCRIPTION
Budget: Added protection to throw if the user of the Budget class atempts to create a new budget for a month that already has a budget
DateTimeUtility: IsSameMonthYear for comparing input DateTime objects to stored ones, also TruncateToMonthYear to clean user input for storage
The ViewData class now sets the currently displayed month and year to the current month and year according to the user's system clock
Budget: GetBudgetMonthByMonthYear (for MainPage, to be deprecated when MainPage ViewModel class is made)
Budget: GetBudgetGoalByMonthYear (for SetGoal page)
Budget: AddExpense (for AddExpense page)
Moved creation of test month to App
Moved creation o ftest expenses to MainBudgetSummaryPage
MainBudgetSummaryPage: BindingContext now directly set to the BudgetMonth of hte current monthyear  on system startup (to be deprecated when MainBudgetSummaryPage gets its own ViewModel class)