### PR TITLE
ExpenseCategory class and data binding example for Andrea's picker control

### DIFF
--- a/MadMoney/MadMoney/App.xaml.cs
+++ b/MadMoney/MadMoney/App.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using MadMoney.Model;
 using MadMoney.View;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -8,12 +10,12 @@ namespace MadMoney
 {
     public partial class App : Application
     {
-        // Global budget instance
         public static Budget GlobalBudget = new Budget();
         public static ViewData GlobalViewData = new ViewData();
 
         public App()
         {
+
             InitializeComponent();
 
             App.GlobalBudget.CreateNewMonth(2000M,

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
@@ -90,45 +90,70 @@
         </StackLayout>
 
 
-        <!-- TODO: Why is this not working? on DataTemplate: x:DataType="data:Expense"
-                Also on ListView: ItemsSource="{Binding expenseCollection}"
-                Currently setting BindingContext instead in MainBudgetSummaryPage constructor -->
-        <ListView x:Name="ExpensesListView"
-                  ItemsSource="{Binding Expenses}">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <ViewCell>
-                        <StackLayout>
-                            <StackLayout Orientation="Horizontal">
-                                <Label Text="{Binding Description}"/>
-                                <!-- TODO: Fix this empty Label hack for 
-                                I can't figure out how else to do the left
-                                and right justify -->
-                                <Label HorizontalOptions="CenterAndExpand"/>
-                                <Label Text="🍎"/> <!-- TODO: Update once emoji conversions are in -->
+        <StackLayout>
+
+            <!-- FOR ANDREA: EXAMPLE CATEGORY DATA BINDING -->
+            <ListView x:Name="DemoExpenseCategoryListView"
+                      ItemsSource="{Binding ExpenseCategories}">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <ViewCell>
+                            <StackLayout>
+                                <StackLayout Orientation="Horizontal">
+                                    <Label Text="{Binding Emoji}"/>
+                                    <Label Text="{Binding Name}"/>
+                                </StackLayout>
                             </StackLayout>
-                            <StackLayout Orientation="Horizontal">
-                                <Label Text="{Binding Date}"/>
-                                <!-- TODO: Fix this empty Label hack for 
-                                I can't figure out how else to do the left
-                                and right justify -->
-                                <Label HorizontalOptions="CenterAndExpand"/>
-                                <Label Text="💲"/>
-                                <Label Text="{Binding Amount}"/>
+                        </ViewCell>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+
+
+            <!-- TODO: Why is this not working? on DataTemplate: x:DataType="data:Expense"
+                    Also on ListView: ItemsSource="{Binding expenseCollection}"
+                    Currently setting BindingContext instead in MainBudgetSummaryPage constructor -->
+            <ListView x:Name="ExpensesListView"
+                      ItemsSource="{Binding Expenses}">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <ViewCell>
+                            <StackLayout>
+                                <StackLayout Orientation="Horizontal">
+                                    <Label Text="{Binding Description}"/>
+                                    <!-- TODO: Fix this empty Label hack for 
+                                    I can't figure out how else to do the left
+                                    and right justify -->
+                                    <Label HorizontalOptions="CenterAndExpand"/>
+                                    <Label Text="🍎"/>
+                                    <!-- TODO: Update once emoji conversions are in -->
+                                </StackLayout>
+                                <StackLayout Orientation="Horizontal">
+                                    <Label Text="{Binding Date}"/>
+                                    <!-- TODO: Fix this empty Label hack for 
+                                    I can't figure out how else to do the left
+                                    and right justify -->
+                                    <Label HorizontalOptions="CenterAndExpand"/>
+                                    <Label Text="💲"/>
+                                    <Label Text="{Binding Amount}"/>
+                                </StackLayout>
                             </StackLayout>
-                        </StackLayout>
-                    </ViewCell>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-            <!-- Check to make sure that expenseCollection contains Expense objects
-            Try making it an ObservableCollection and see if that makes a difference
-            Could also try BindingContext...though I see Xamarin examples that use
-            ItemsSource?? -->
-
-        </ListView>
+                        </ViewCell>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
 
 
-        <!-- TODO: Remove this  -->
+
+
+            
+        </StackLayout>
+
+            
+            
+            
+            <!-- TODO: Remove this? Depends on whether the Add Expense button
+        at the top of the page is visible or not -->
         <Button x:Name="AddExpenseButton_Bottom"
                 Text="Add Expense"
                 FontSize="22"

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -13,27 +13,20 @@ namespace MadMoney
     [DesignTimeVisible(false)]
     public partial class MainBudgetSummaryPage : ContentPage
     {
-        private MainBudgetSummaryPageViewModel ViewModel;
-
+        private MainBudgetSummaryPageViewModel ViewModel = null;
 
         public MainBudgetSummaryPage()
         {
             App.GlobalBudget.AddExpense("Amazon.com",
                             125.37M,
                             DateTime.Parse("2020-03-13"),
-                            ExpenseCategory.TreatYoSelf);
+                            ExpenseCategory.Enum.TreatYoSelf);
 
 
             App.GlobalBudget.AddExpense("Trader Joe's",
                             42.50M,
                             DateTime.Parse("2020-03-01"),
-                            ExpenseCategory.Groceries);
-
-
-
-            // BindingContext = App.GlobalBudget.GetBudgetMonthByMonthYear(
-            //                        App.GlobalViewData.CurrentlyDisplayedMonthYear);
-
+                            ExpenseCategory.Enum.Groceries);
           
 
             BindingContext = ViewModel = new MainBudgetSummaryPageViewModel();
@@ -60,7 +53,7 @@ namespace MadMoney
             //string des = "Trader Joe's";
             //decimal amt = 245.90M;
             //DateTime date = DateTime.Parse("2020-02-01");
-            //ExpenseCategory cat = ExpenseCategory.Groceries;
+            //ExpenseCategory.Enum cat = ExpenseCategory.Enum.Groceries;
             //App.GlobalBudget.AddExpense(des, amt, date, cat);
 
 

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -13,6 +13,8 @@ namespace MadMoney
     [DesignTimeVisible(false)]
     public partial class MainBudgetSummaryPage : ContentPage
     {
+        private MainBudgetSummaryPageViewModel ViewModel;
+
 
         public MainBudgetSummaryPage()
         {
@@ -28,15 +30,13 @@ namespace MadMoney
                             ExpenseCategory.Groceries);
 
 
+
             // BindingContext = App.GlobalBudget.GetBudgetMonthByMonthYear(
             //                        App.GlobalViewData.CurrentlyDisplayedMonthYear);
 
+          
 
-            BindingContext = new MainBudgetSummaryPageViewModel();
-
-
-
-
+            BindingContext = ViewModel = new MainBudgetSummaryPageViewModel();
 
 
 
@@ -67,13 +67,13 @@ namespace MadMoney
             // Simlar demo code for Ainur's Save button on the GetGoal page
             //App.GlobalBudget.CreateNewMonth(amt, date);
 
-            MainPageTestManager.UpdateGoal( MainPageTestManager.GetTestMonth().BudgetGoal - 100);
+            MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal - 100);
             return;
         }
 
         private void NextMonthButton_Pressed(object sender, EventArgs e)
         {
-            MainPageTestManager.UpdateGoal(MainPageTestManager.GetTestMonth().BudgetGoal + 100);
+            MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal + 100);
             return;
         }
 

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -13,6 +13,7 @@ namespace MadMoney
     [DesignTimeVisible(false)]
     public partial class MainBudgetSummaryPage : ContentPage
     {
+
         public MainBudgetSummaryPage()
         {
             App.GlobalBudget.AddExpense("Amazon.com",
@@ -27,8 +28,17 @@ namespace MadMoney
                             ExpenseCategory.Groceries);
 
 
-            BindingContext = App.GlobalBudget.GetBudgetMonthByMonthYear(
-                                    App.GlobalViewData.CurrentlyDisplayedMonthYear);
+            // BindingContext = App.GlobalBudget.GetBudgetMonthByMonthYear(
+            //                        App.GlobalViewData.CurrentlyDisplayedMonthYear);
+
+
+            BindingContext = new MainBudgetSummaryPageViewModel();
+
+
+
+
+
+
 
             InitializeComponent();
 

--- a/MadMoney/MadMoney/Model/Budget.cs
+++ b/MadMoney/MadMoney/Model/Budget.cs
@@ -56,6 +56,19 @@ namespace MadMoney.Model
                 DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear)).BudgetGoal;
         }
 
+        public void SetBudgetGoalByMonthYear(decimal goal, DateTime monthYear)
+        {
+            // If the month specified by the caller doesn't exist, throw
+            if (false == budgetMonths.Exists(month =>
+                DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear)))
+            {
+                throw new ArgumentException($"No budget exists for {monthYear.ToString()}. Cannot set goal.");
+            }
+
+            budgetMonths.Find(month =>
+                DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear)).BudgetGoal = goal;
+        }
+
         public void AddExpense(string expDescrip,
                                decimal expAmt,
                                DateTime expDate,

--- a/MadMoney/MadMoney/Model/Expense.cs
+++ b/MadMoney/MadMoney/Model/Expense.cs
@@ -32,6 +32,18 @@ namespace MadMoney.Model
 
 
 
+
+    public class ExpenseCategory2
+    {
+        public ExpenseCategory Category { get; set; }
+
+
+    }
+
+
+
+
+
     public class Expense // : INotifyPropertyChanged <- May not need this
         // May ultimately be unnnecessary as I don't think that an Expense
         // can change while a page is loaded (rather between pages)

--- a/MadMoney/MadMoney/Model/Expense.cs
+++ b/MadMoney/MadMoney/Model/Expense.cs
@@ -1,50 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 
 namespace MadMoney.Model
 {
-    // ? Write a proposal for this class
-  
-    //public class ExpenseCategory2
-    //{
-    //    public char Emoji { get; set; }
-    //    public string Name { get; set; }
-    //}
-
-    
-    // TODO (Lynn):
-    // ExpenseCategory more appropriately its own class type
-    // rather than just an enum.
-    // to contain the emoji that corresponds to each category
-    // as well as the string the corresponds to each category
-    public enum ExpenseCategory
-    { 
-        Groceries,
-        Restaurants,
-        Rent,
-        Healthcare,
-        Gifts,
-        TreatYoSelf
-    }
-
-
-
-
-
-    public class ExpenseCategory2
-    {
-        public ExpenseCategory Category { get; set; }
-
-
-    }
-
-
-
-
-
-    public class Expense // : INotifyPropertyChanged <- May not need this
+        public class Expense // : INotifyPropertyChanged <- May not need this
         // May ultimately be unnnecessary as I don't think that an Expense
         // can change while a page is loaded (rather between pages)
         // Bindings are re-established each time a Page is loaded, correct?
@@ -132,13 +92,14 @@ namespace MadMoney.Model
 
 
         /// <summary>
-        /// Category of the Expense. (Currently of ExpenseCategory enum type.)
+        /// Category of the Expense.
         /// Example: Groceries
         /// </summary>
-        // TODO: Needs to be updated to be of the type of the enum class wrapper type
-        // that Lynn is working on this as a part of Filter Expenses page development
-        // This new class type to get its own cs file, correct?
         public ExpenseCategory Category { get; set; }
+        // TODO: Remember when serializing this property to file
+        // Serialize as the string representation of the enum
+        // Not the value. String is sturdier. More likely to withstand
+        // changes to the enum between between builds of the app
 
 
         // ** NOTE:
@@ -149,6 +110,5 @@ namespace MadMoney.Model
         // Subjective whether file i/o class should be interacted with
         // by the ViewModel or the Model
         // Pros and cons for each
-        // TODO: Ask Kal/TAs
     }
 }

--- a/MadMoney/MadMoney/Model/ExpenseCategory.cs
+++ b/MadMoney/MadMoney/Model/ExpenseCategory.cs
@@ -1,0 +1,115 @@
+﻿using System;
+
+namespace MadMoney.Model
+{
+    // TODO: Remember when serializing this property to file
+    // Serialize as the string representation of the enum
+    // Not the value. String is sturdier. More likely to withstand
+    // changes to the enum between between builds of the app
+    public struct ExpenseCategory
+    {
+        public enum Enum
+        {
+            Groceries,
+            Restaurants,
+            Rent,
+            Healthcare,
+            Gifts,
+            TreatYoSelf
+        }
+
+        // One emojiArray to rule them all
+        // This is the array of emojis that the
+        // Emoji property uses to look up the emoji for this ExpenseCategory
+        private static string[] emojiArray = null;
+
+        private static void SetupEmojiArray()
+        {
+            emojiArray =
+            new string[System.Enum.GetNames(typeof(Enum)).Length];
+
+            // These are set here in a setup method instead of done
+            // using an init list at declaration to make changing
+            // emoji easier to do and less error-prone
+            // Note how the name of each catetory is visually right next
+            // to its emoji in the set of assignment statements below:
+            emojiArray[(int)Enum.Groceries]   = "🍎";
+            emojiArray[(int)Enum.Restaurants] = "🍝";
+            emojiArray[(int)Enum.Rent]        = "🏠";
+            emojiArray[(int)Enum.Healthcare]  = "💉";
+            emojiArray[(int)Enum.Gifts]       = "🎁";
+            emojiArray[(int)Enum.TreatYoSelf] = "🍧";
+        }
+
+
+
+        public ExpenseCategory(ExpenseCategory.Enum catId)
+        {
+            Id = catId;
+        }
+
+        // Allow implicit type conversion from the enum type to the class type
+        // No data can be lost, so this is permissible
+        // https://stackoverflow.com/questions/261663/can-we-define-implicit-conversions-of-enums-in-c/261696#261696
+        public static implicit operator ExpenseCategory(ExpenseCategory.Enum input)
+        {
+            return new ExpenseCategory(input);
+        }
+
+
+        public Enum Id { get; set; }
+
+        public string Emoji
+        {
+            get
+            {
+                if (emojiArray == null)
+                {
+                    SetupEmojiArray();
+                }
+
+                return emojiArray[(int)Id];
+            }
+        }
+
+        public string Name
+        {
+            get
+            {
+                return ToString();
+            }
+        }
+
+        public override string ToString()
+        {
+            // QUESTION: Is there a performance hit to using ToString on an enum value?
+            // My intuition says that there would be some sort of reflection involved
+            return Id.ToString();
+        }
+
+
+        public override bool Equals(object obj)
+        {
+            var toCompare = (ExpenseCategory)obj;
+
+            return (Id == toCompare.Id);
+
+        }
+
+        public override int GetHashCode()
+        {
+            // TODO: Figure out what need to do about this
+            throw new NotImplementedException();
+        }
+
+        public static bool operator ==(ExpenseCategory left, ExpenseCategory right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ExpenseCategory left, ExpenseCategory right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/MadMoney/MadMoney/Model/ExpenseCategoryManager.cs
+++ b/MadMoney/MadMoney/Model/ExpenseCategoryManager.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace MadMoney.Model
+{
+    // Creates and provides access to the single, immutable collection 
+
+    // Note that the collection is immutable, but the ExpenseCategory objects
+    // within it are mutable. Ideally the ExpenseCategory objects would be immutable.
+    // Could design an IReadOnlyExpenseCategory interface for this purpose
+    // ExpenseCategory class itself can't be immutable, though, else changing the
+    // category of an expense (on the EditExpense page) would not be possible
+    static public class ExpenseCategoryManager
+    {
+        private static ReadOnlyCollection<ExpenseCategory> _collection = null;
+        public static ReadOnlyCollection<ExpenseCategory> Collection
+        {
+            get
+            {
+                // If the collection has already been constructed
+                if (_collection != null)
+                {
+                    return _collection;
+                }
+
+                var categoryList = new List<ExpenseCategory>();
+                foreach (var category in
+                    System.Enum.GetValues(typeof(ExpenseCategory.Enum)))
+                {
+                    categoryList.Add(
+                        new ExpenseCategory((ExpenseCategory.Enum)category));
+                }
+
+                return _collection = new ReadOnlyCollection<ExpenseCategory>(categoryList);
+            }
+        }
+    }
+}

--- a/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
+++ b/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MadMoney.Model;
+
+namespace MadMoney.ViewModel
+{
+    public class MainBudgetSummaryPageViewModel
+    {
+        public MainBudgetSummaryPageViewModel()
+        { 
+        
+        }
+
+        public decimal BudgetGoal
+        {
+            get
+            {
+                return App.GlobalBudget.GetBudgetGoalByMonthYear(App.GlobalViewData.CurrentlyDisplayedMonthYear);
+            }
+
+        }
+
+        //public IEnumerable<Expense> Expenses
+        //{
+        //    get
+        //    {
+        //        return App.GlobalBudget.GetBudgetMonthByMonthYear(;
+        //    }
+        //}
+
+
+    }
+}

--- a/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
+++ b/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using MadMoney.Model;
 
@@ -21,6 +22,14 @@ namespace MadMoney.ViewModel
 
         }
 
+
+        // For testing purposes only
+        public static void UpdateGoal(decimal newGoal)
+        {
+            App.GlobalBudget.GetBudgetMonthByMonthYear(App.GlobalViewData.CurrentlyDisplayedMonthYear).BudgetGoal = newGoal;
+
+        }
+
         //public IEnumerable<Expense> Expenses
         //{
         //    get
@@ -28,6 +37,10 @@ namespace MadMoney.ViewModel
         //        return App.GlobalBudget.GetBudgetMonthByMonthYear(;
         //    }
         //}
+
+
+
+        
 
 
     }

--- a/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
+++ b/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using MadMoney.Model;
@@ -22,13 +23,24 @@ namespace MadMoney.ViewModel
 
         }
 
+        public ReadOnlyCollection<ExpenseCategory> ExpenseCategories
+        {
+            get
+            {
+                return ExpenseCategoryManager.Collection;
+            }
+        }
+
 
         // For testing purposes only
         public static void UpdateGoal(decimal newGoal)
         {
-            App.GlobalBudget.GetBudgetMonthByMonthYear(App.GlobalViewData.CurrentlyDisplayedMonthYear).BudgetGoal = newGoal;
+            App.GlobalBudget.GetBudgetMonthByMonthYear(
+                App.GlobalViewData.CurrentlyDisplayedMonthYear).BudgetGoal = newGoal;
 
         }
+
+
 
         //public IEnumerable<Expense> Expenses
         //{

--- a/MadMoney/MadMoney/ViewModel/MainPageTestManager.cs
+++ b/MadMoney/MadMoney/ViewModel/MainPageTestManager.cs
@@ -12,21 +12,8 @@ namespace MadMoney.ViewModel
     // Creates a dummy BudgetMonth so that the UI can bind to it
     public static class MainPageTestManager
     {
-        public static BudgetMonth GetTestMonth()
-        {
 
 
-
-
-
-            return App.GlobalBudget.BudgetMonths.ToArray()[0];
-        }
-
-
-        public static void UpdateGoal(decimal newGoal)
-        {
-            App.GlobalBudget.BudgetMonths.ToArray()[0].BudgetGoal = newGoal;
-        }
 
     }
 }


### PR DESCRIPTION
Andrea, to check it out, go to my MainBudgetSummaryPage.xaml and find the following comment:
FOR ANDREA: EXAMPLE CATEGORY DATA BINDING
Below it you'll see how I data bound a collection of ExpenseCategory objects to a ListView (note that ExpenseCategory is now a class instead of an enum. The old enum is now an inner type to (that is, delcared within) the ExpenseCategory class type

ExpenseCategory is now a class type instead of an enum type. Stores state only as a single enum Id field. Provides string access in the Name property and icon access in the Emoji property.

Emoji is done internally as an array lookup using the enum values.
The former enum is inner to that class: ExpenseCategory.Enum.
Provide implicit conversion from ExpenseCategory.Enum to ExpenseCategory (for conveneince and backwards compatability)
ExpenseCategoryManager.Collection is globally visible as the immutable collection of (unfortunately mutable) ExpenseCategory objects that represent all of the categories in the app