### PR TITLE
Main page UI: Prev/Next Month, Budget Goal, Budget Remaining, Total Expenses, Emoji, Formatting, 

### DIFF
--- a/MadMoney/MadMoney/App.xaml.cs
+++ b/MadMoney/MadMoney/App.xaml.cs
@@ -18,6 +18,10 @@ namespace MadMoney
 
             InitializeComponent();
 
+            // TODO: Replace/delete this placeholder
+            // Temporary month creation call until Ainur's AddGoal page is
+            // ready to handle creating the initial month when the user sets
+            // their initial goal
             App.GlobalBudget.CreateNewMonth(2000M,
                                 DateTime.Parse("2020-03-01"));
 

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
@@ -14,18 +14,19 @@
             <Button x:Name="PreviousMonthButton"
                 Text="👈"
                 FontSize="30"
-                BackgroundColor="Purple"
+                BackgroundColor="MediumPurple"
                 Pressed="PreviousMonthButton_Pressed"/>
 
             <Label x:Name="CurrentMonthLabel"
                 Text="{Binding MonthYear_ForCurrentlyShownMonth_String}"
                 FontSize="30"
-                HorizontalOptions="CenterAndExpand"/>
+                HorizontalOptions="CenterAndExpand"
+                VerticalOptions="CenterAndExpand"/>
 
             <Button x:Name="NextMonthButton"
                 Text="👉"
                 FontSize="30"
-                BackgroundColor="Purple"
+                BackgroundColor="MediumPurple"
                 Pressed="NextMonthButton_Pressed"/>
         </StackLayout>
 
@@ -79,7 +80,7 @@
 
             <Button x:Name="AddExpenseButton_Top"
                 Text="Add Expense"
-                FontSize="22"
+                FontSize="16"
                 BackgroundColor="LightGreen"
                 Pressed="AddExpenseButton_Top_Pressed"/>
 
@@ -88,9 +89,20 @@
                                 and right justify -->
             <Label HorizontalOptions="CenterAndExpand"/>
 
+            <Button x:Name="EditBudgetGoalButton"
+                Text="Edit Goal"
+                FontSize="16"
+                BackgroundColor="LightSalmon"
+                Pressed="EditBudgetGoalButton_Pressed"/>
+
+            <!-- TODO: Fix this empty Label hack for 
+                                I can't figure out how else to do the left
+                                and right justify -->
+            <Label HorizontalOptions="CenterAndExpand"/>
+
             <Button x:Name="FilterExpensesButton"
                 Text="Filter Expenses"
-                FontSize="22"
+                FontSize="16"
                 BackgroundColor="LightBlue"
                 Pressed="FilterExpensesButton_Pressed"/>
         </StackLayout>
@@ -113,11 +125,11 @@
                                     I can't figure out how else to do the left
                                     and right justify -->
                                     <Label HorizontalOptions="CenterAndExpand"/>
-                                    <Label Text="🍎"/>
+                                    <Label Text="{Binding Category.Emoji}"/>
                                     <!-- TODO: Update once emoji conversions are in -->
                                 </StackLayout>
                                 <StackLayout Orientation="Horizontal">
-                                    <Label Text="{Binding Date}"/>
+                                    <Label Text="{Binding Date, StringFormat='{0:MM/dd/yyyy}'}"/>
                                     <!-- TODO: Fix this empty Label hack for 
                                     I can't figure out how else to do the left
                                     and right justify -->
@@ -132,19 +144,16 @@
             </ListView>
 
 
-
-
-            
         </StackLayout>
 
             
             
             
-            <!-- TODO: Remove this? Depends on whether the Add Expense button
+        <!-- TODO: Remove this? Depends on whether the Add Expense button
         at the top of the page is visible or not -->
         <Button x:Name="AddExpenseButton_Bottom"
                 Text="Add Expense"
-                FontSize="22"
+                FontSize="16"
                 BackgroundColor="LightGreen"/>
 
     </StackLayout>

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
@@ -18,7 +18,7 @@
                 Pressed="PreviousMonthButton_Pressed"/>
 
             <Label x:Name="CurrentMonthLabel"
-                Text="February 2020"
+                Text="{Binding MonthYear_ForCurrentlyShownMonth_String}"
                 FontSize="30"
                 HorizontalOptions="CenterAndExpand"/>
 

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
@@ -38,7 +38,7 @@
             <Label HorizontalOptions="CenterAndExpand"/>
             <Label Text="💲"/>
             <Label x:Name="BudgetGoalText"
-                   Text="{Binding BudgetGoal}"/>
+                   Text="{Binding BudgetGoal_ForCurrentlyShownMonth_String}"/>
             <Label Text="🖍️"/>
 
         </StackLayout>
@@ -50,7 +50,11 @@
                                 I can't figure out how else to do the left
                                 and right justify -->
             <Label HorizontalOptions="CenterAndExpand"/>
-            <Label Text="💲1,457.0"/>
+            <Label Text="💲"/>
+            <Label x:Name="BudgetRemainingText"
+                   Text="{Binding BudgetRemaining_ForCurrentlyShownMonth_String}"/>
+            <!-- TODO: Update color/icon to reflect whether the user is below,
+            at, or beyond their budget goal. -->
             <Label Text="🆗"/>
 
         </StackLayout>
@@ -62,7 +66,9 @@
                                 I can't figure out how else to do the left
                                 and right justify -->
             <Label HorizontalOptions="CenterAndExpand"/>
-            <Label Text="💲543.00"/>
+            <Label Text="💲"/>
+            <Label x:Name="TotalExpensesText"
+                   Text="{Binding TotalExpenses_ForCurrentlyShownMonth_String}"/>
             <Label Text="💸"/>
 
         </StackLayout>
@@ -91,24 +97,6 @@
 
 
         <StackLayout>
-
-            <!-- FOR ANDREA: EXAMPLE CATEGORY DATA BINDING -->
-            <ListView x:Name="DemoExpenseCategoryListView"
-                      ItemsSource="{Binding ExpenseCategories}">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <ViewCell>
-                            <StackLayout>
-                                <StackLayout Orientation="Horizontal">
-                                    <Label Text="{Binding Emoji}"/>
-                                    <Label Text="{Binding Name}"/>
-                                </StackLayout>
-                            </StackLayout>
-                        </ViewCell>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
-
 
             <!-- TODO: Why is this not working? on DataTemplate: x:DataType="data:Expense"
                     Also on ListView: ItemsSource="{Binding expenseCollection}"

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
@@ -135,7 +135,7 @@
                                     and right justify -->
                                     <Label HorizontalOptions="CenterAndExpand"/>
                                     <Label Text="💲"/>
-                                    <Label Text="{Binding Amount}"/>
+                                    <Label Text="{Binding Amount, StringFormat='{0:N2}'}"/>
                                 </StackLayout>
                             </StackLayout>
                         </ViewCell>

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -13,6 +13,7 @@ namespace MadMoney
     [DesignTimeVisible(false)]
     public partial class MainBudgetSummaryPage : ContentPage
     {
+        // May not need to retain a reference to the ViewModel instance
         private MainBudgetSummaryPageViewModel ViewModel = null;
 
         public MainBudgetSummaryPage()
@@ -21,7 +22,6 @@ namespace MadMoney
                             125.37M,
                             DateTime.Parse("2020-03-13"),
                             ExpenseCategory.Enum.TreatYoSelf);
-
 
             App.GlobalBudget.AddExpense("Trader Joe's",
                             42.50M,
@@ -49,6 +49,7 @@ namespace MadMoney
                             ExpenseCategory.Enum.Healthcare);
 
 
+            // May not need to retain a reference to the ViewModel instance
             BindingContext = ViewModel = new MainBudgetSummaryPageViewModel();
 
 
@@ -61,8 +62,79 @@ namespace MadMoney
             // BudgetGoalText.Text = String.Empty;
         }
 
+
         private void PreviousMonthButton_Pressed(object sender, EventArgs e)
         {
+            ViewModel.LoadPreviousMonth();
+
+            // Clear the BindingContext for the MainPage, then set it back to
+            // the same ViewModel. Goal is to force the UI to re-query all
+            // the properties that it is bound to on the viewmodel.
+            BindingContext = null;
+            BindingContext = ViewModel;
+            // For some reason setting it to null is required, doesn't work
+            // without that. I wonder why!
+            // Perhaps the compiler optimizes away the re-assignment of ViewModel
+            // to BindingContext, as though it could not possibly have an effect?
+            // This viewmodel class type, while instantiable, has no state.
+            // Wait. If the class type truly has no state, it should probably
+            // be static after all. Whoops! I'll attribute that design oversight
+            // to me being new to using properties on classes.
+
+
+            // TODO: OBSERVE AND VERIFY
+            // (Does that work for getting all of the UI elements to refresh?)
+            // Yes, it does.
+            // Probably still the best practice to navigate back to the main
+            // (That is, the MainPage navigating to itself)
+
+            // See also:
+            // Budget.AddExpense() for another place that is currently
+            // making a call to create a new month that doesn't yet exist
+            // In this case, need more elaborate logic
+
+
+
+            // Since migrating the data binding to a proper viewmodel, this
+            // vestigal UI demo no longer functions.
+            //MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal_ForCurrentlyShownMonth_Decimal - 100);
+
+        }
+
+        private void NextMonthButton_Pressed(object sender, EventArgs e)
+        {
+            ViewModel.LoadNextMonth();
+
+            // Clear the BindingContext for the MainPage, then set it back to
+            // the same ViewModel. Goal is to force the UI to re-query all
+            // the properties that it is bound to on the viewmodel.
+            BindingContext = null;
+            BindingContext = ViewModel;
+            // For some reason setting it to null is required, doesn't work
+            // without that. I wonder why!
+            // Perhaps the compiler optimizes away the re-assignment of ViewModel
+            // to BindingContext, as though it could not possibly have an effect?
+            // This viewmodel class type, while instantiable, has no state.
+            // Wait. If the class type truly has no state, it should probably
+            // be static after all. Whoops! I'll attribute that design oversight
+            // to me being new to using properties on classes.
+
+
+            // TODO: OBSERVE AND VERIFY
+            // (Does that work for getting all of the UI elements to refresh?)
+            // Yes, it does.
+            // Probably still the best practice to navigate back to the main
+            // (That is, the MainPage navigating to itself)
+
+            // See also:
+            // Budget.AddExpense() for another place that is currently
+            // making a call to create a new month that doesn't yet exist
+            // In this case, need more elaborate logic
+
+
+            // Since migrating the data binding to a proper viewmodel, this
+            // vestigal UI demo no longer functions.
+            //MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal_ForCurrentlyShownMonth_Decimal + 100);
 
 
             // Demo code for when we were pretending that this was Andrea's
@@ -80,14 +152,6 @@ namespace MadMoney
             // Simlar demo code for Ainur's Save button on the GetGoal page
             //App.GlobalBudget.CreateNewMonth(amt, date);
 
-            MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal_ForCurrentlyShownMonth_Decimal - 100);
-            return;
-        }
-
-        private void NextMonthButton_Pressed(object sender, EventArgs e)
-        {
-            MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal_ForCurrentlyShownMonth_Decimal + 100);
-            return;
         }
 
         private void AddExpenseButton_Top_Pressed(object sender, EventArgs e)

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -27,7 +27,27 @@ namespace MadMoney
                             42.50M,
                             DateTime.Parse("2020-03-01"),
                             ExpenseCategory.Enum.Groceries);
-          
+
+            App.GlobalBudget.AddExpense("Veggie Grill",
+                            29.65M,
+                            DateTime.Parse("2020-03-29"),
+                            ExpenseCategory.Enum.Restaurants);
+
+            App.GlobalBudget.AddExpense("Sanrio",
+                            76.34M,
+                            DateTime.Parse("2020-03-25"),
+                            ExpenseCategory.Enum.Gifts);
+
+            App.GlobalBudget.AddExpense("Rent",
+                            1000M,
+                            DateTime.Parse("2020-03-1"),
+                            ExpenseCategory.Enum.Rent);
+
+            App.GlobalBudget.AddExpense("Copay",
+                            20M,
+                            DateTime.Parse("2020-03-12"),
+                            ExpenseCategory.Enum.Healthcare);
+
 
             BindingContext = ViewModel = new MainBudgetSummaryPageViewModel();
 

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -79,5 +79,10 @@ namespace MadMoney
         {
 
         }
+
+        private void EditBudgetGoalButton_Pressed(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -60,13 +60,13 @@ namespace MadMoney
             // Simlar demo code for Ainur's Save button on the GetGoal page
             //App.GlobalBudget.CreateNewMonth(amt, date);
 
-            MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal - 100);
+            MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal_ForCurrentlyShownMonth_Decimal - 100);
             return;
         }
 
         private void NextMonthButton_Pressed(object sender, EventArgs e)
         {
-            MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal + 100);
+            MainBudgetSummaryPageViewModel.UpdateGoal( ViewModel.BudgetGoal_ForCurrentlyShownMonth_Decimal + 100);
             return;
         }
 

--- a/MadMoney/MadMoney/Model/Budget.cs
+++ b/MadMoney/MadMoney/Model/Budget.cs
@@ -44,10 +44,17 @@ namespace MadMoney.Model
         }
 
 
+        // Ideally remove this method in the interest of making BudgetMonth
+        // a class that is internal to the Model implementation
         public BudgetMonth GetBudgetMonthByMonthYear(DateTime monthYear)
         {
             return budgetMonths.Find(month =>
                     DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear));
+        }
+
+        public IEnumerable<Expense> GetExpensesByMonthYear(DateTime monthYear)
+        {
+            return GetBudgetMonthByMonthYear(monthYear).Expenses;
         }
 
         public decimal GetBudgetGoalByMonthYear(DateTime monthYear)
@@ -85,6 +92,7 @@ namespace MadMoney.Model
             if (budgetMonthOfExpense == null)
             {
                 // TODO: LOOK UP WHAT THE GOAL SHOULD BE FOR A NEW MONTH THAT IS CREATED FROM ADD EXPENSE
+                // REVIEW THE DESIGN TO SEE WHERE WE SHOULD GET THIS FROM.
                 budgetMonths.Add(new BudgetMonth(
                         999999M, DateTimeUtility.TruncateToMonthYear(expDate)));
 

--- a/MadMoney/MadMoney/Model/Budget.cs
+++ b/MadMoney/MadMoney/Model/Budget.cs
@@ -5,8 +5,10 @@ using MadMoney.Utility;
 
 namespace MadMoney.Model
 {
-    // Not static or singleton as it may make sense in the (hypothetical) future
-    // to have more than one Budget (that is, set of BudgetMonths)
+    // Budget is not static or singleton as it may make sense in the
+    // (hypothetical) future to have more than one Budget
+    // that is, multiple Budget instances
+    // for example, a different Budget for each user, etc.
     public class Budget
     {
         private List<BudgetMonth> budgetMonths;
@@ -16,7 +18,8 @@ namespace MadMoney.Model
         }
 
         // TODO:
-        //BudgetMonth class type is best as an implementation detail of the Model
+        // Make the BudgetMonth an internal class type,
+        // an implementation detail of the Model
         public IEnumerable<BudgetMonth> BudgetMonths
         { get { return budgetMonths; } }
         // may need to provide additional ways to access/modify BudgetMonths collection
@@ -31,9 +34,11 @@ namespace MadMoney.Model
             }
 
 
-            // Idea: Add the new month to the beginning of the list?
+            // Idea:
+            // Add the new month to the beginning of the list?
             // it is probably the month that is most likely to be accessed
-            // We'd need to switch data structure for that to be a good idea:
+            // Turns out that  we would need to switch data structures for
+            // that to be a good idea:
             // https://stackoverflow.com/questions/705969/adding-object-to-the-beginning-of-generic-listt
 
 
@@ -44,7 +49,7 @@ namespace MadMoney.Model
         }
 
 
-        // Ideally remove this method in the interest of making BudgetMonth
+        // Ideally deprecate this method in the interest of making BudgetMonth
         // a class that is internal to the Model implementation
         public BudgetMonth GetBudgetMonthByMonthYear(DateTime monthYear)
         {
@@ -63,11 +68,16 @@ namespace MadMoney.Model
                 DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear)).BudgetGoal;
         }
 
+        public bool BudgetMonthExistByMonthYear(DateTime monthYear)
+        {
+            return budgetMonths.Exists(month =>
+                DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear));
+        }
+
         public void SetBudgetGoalByMonthYear(decimal goal, DateTime monthYear)
         {
             // If the month specified by the caller doesn't exist, throw
-            if (false == budgetMonths.Exists(month =>
-                DateTimeUtility.IsSameMonthYear(month.MonthYear, monthYear)))
+            if (false == BudgetMonthExistByMonthYear(monthYear))
             {
                 throw new ArgumentException($"No budget exists for {monthYear.ToString()}. Cannot set goal.");
             }
@@ -81,7 +91,6 @@ namespace MadMoney.Model
                                DateTime expDate,
                                ExpenseCategory expCat)
         {
-
             // Step through the list of months
             // Find the month for which to add the expense
             var budgetMonthOfExpense = budgetMonths.Find(month =>
@@ -91,13 +100,18 @@ namespace MadMoney.Model
             // If the month is not found, create the new month
             if (budgetMonthOfExpense == null)
             {
-                // TODO: LOOK UP WHAT THE GOAL SHOULD BE FOR A NEW MONTH THAT IS CREATED FROM ADD EXPENSE
+                // TODO: LOOK UP WHAT THE GOAL SHOULD BE FOR A NEW MONTH THAT
+                // IS CREATED FROM ADD EXPENSE
                 // REVIEW THE DESIGN TO SEE WHERE WE SHOULD GET THIS FROM.
-                budgetMonths.Add(new BudgetMonth(
-                        999999M, DateTimeUtility.TruncateToMonthYear(expDate)));
+                CreateNewMonth(999999M, expDate);
 
                 budgetMonthOfExpense = budgetMonths.Find(month =>
                     DateTimeUtility.IsSameMonthYear(month.MonthYear, expDate));
+
+                // TODO:
+                // IT'S THE VIEW'S JOB TO SWITCH THE DISPLAYED MONTH IN THE UI
+                // NOT APPROPRIATE FOR THE MODEL TO CHANGE WHICH MONTH
+                // THE VIEW IS DISPLAYING
             }
 
 

--- a/MadMoney/MadMoney/Model/BudgetMonth.cs
+++ b/MadMoney/MadMoney/Model/BudgetMonth.cs
@@ -58,22 +58,13 @@ namespace MadMoney.Model
                     NotifyPropertyChanged();
                 }
         }
-        // Expense can go over budget goal
+        // Design allows for expenses to exceed the budget goal
 
-
-        // TODO: Move AmountRemainingInBudgetGoal and any other methods
-        // that calculate and return 
-        // if it's not data that the Model stores, then it is something you calculate
-        // That calculation is business logic and belongs in the ViewModel
-        public decimal AmountRemainingInBudgetGoal { get; }
-        // If AmountRemainingInBudgetGoal > 0, user has budget left this month
-        // If AmountRemainingInBudgetGoal == 0, user has used up budget exactly
-        // If AmountRemainingInBudgetGoal < 0, user has exceeded budget
 
         // TODO:
         // Any date in a month is valid input
-        // However, unlike Expense, extra data (that is: day, hour, minute, second)
-        // is truncated as it has no reasonable use.
+        // However, unlike Expense, *** extra data (that is: day, hour, minute, second)
+        // is truncated as it has no reasonable use. ***
         // Specifically, MonthYear represents the duration of one month in a year
         // rather than a specific point in the year
         public DateTime MonthYear { get; }
@@ -84,9 +75,7 @@ namespace MadMoney.Model
         public IEnumerable<Expense> Expenses {
             get { return expenseCollection; }
         }
-        // Instead of: public IEnumerable<Expense> GetExpenses() { return null; }
 
-        // may need to provide additional ways to access/modify Expense collection
 
         public void AddExpense(Expense exp)
         {

--- a/MadMoney/MadMoney/View/ViewData.cs
+++ b/MadMoney/MadMoney/View/ViewData.cs
@@ -11,6 +11,10 @@ namespace MadMoney.View
         // Discard partial data, set the DateTime to be the first of the month.
         // Day-of-the month has no meaning, so best to have it be the same
         // for all of them.
+
+        // Note that there is no special case for the first run of the app.
+        // The app always starts up and defaults to the current month according
+        // to the user's device clock.
         public ViewData()
         {
             CurrentlyDisplayedMonthYear = DateTimeUtility.TruncateToMonthYear(DateTime.Today);

--- a/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
+++ b/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
@@ -47,7 +47,7 @@ namespace MadMoney.ViewModel
                 var expenses = App.GlobalBudget.GetExpensesByMonthYear(
                             App.GlobalViewData.CurrentlyDisplayedMonthYear);
 
-                // Sum in LINQ with a selector:
+                // Sum in LINQ using a selector:
                 // https://www.csharp-examples.net/linq-sum/
                 return expenses.ToList().Sum(expense => expense.Amount);
             }
@@ -81,30 +81,12 @@ namespace MadMoney.ViewModel
 
 
 
-        // Expense Categories only exposed to the View here for purpose of demoing to Andrea for Add/Edit expense
-        public ReadOnlyCollection<ExpenseCategory> ExpenseCategories
-        {
-            get
-            {
-                return ExpenseCategoryManager.Collection;
-            }
-        }
 
-
-        // For testing purposes only
-        public static void UpdateGoal(decimal newGoal)
-        {
-            App.GlobalBudget.GetBudgetMonthByMonthYear(
-                App.GlobalViewData.CurrentlyDisplayedMonthYear).BudgetGoal = newGoal;
-
-        }
-
-
-
-        // Ideally, the ViewModel would do string formatting for the View for expenses
-        // I think this would involve programmatically configuring the ItemTemplate,
-        // DataTemplate, or ViewCell of the ListView
-        // For now, setting the formatting directly in the XAML
+        // TODO:
+        // Ideally, the ViewModel would handle all string formatting for the View.
+        // Seems like this would involve programmatically configuring the ItemTemplate,
+        // DataTemplate, and/or ViewCell of the ListView
+        // (For now, setting the formatting directly in the XAML)
         public IEnumerable<Expense> Expenses
         {
             get
@@ -116,6 +98,68 @@ namespace MadMoney.ViewModel
 
 
 
+        // Maybe the methods on the viewmodel class should be static and thus invoked
+        // using the class name rather than from the instance of the viewmodel
+        // that the view has.
+        // Would better follows Kal's example of the static SoundManager class
+        public void LoadPreviousMonth()
+        {
+            LoadAdjacentMonthHelper(AdjacentMonth.Previous);
+        }
+
+        public void LoadNextMonth()
+        {
+            LoadAdjacentMonthHelper(AdjacentMonth.Next);
+        }
+
+        // Represents the number of months to add or subtract from a DateTime
+        private enum AdjacentMonth
+        { 
+            Previous = -1,
+            Next = 1
+        }
+
+
+        private void LoadAdjacentMonthHelper(AdjacentMonth direction)
+        {
+            // Determine which chronological month we are going to
+            DateTime destMonth =
+                App.GlobalViewData.CurrentlyDisplayedMonthYear.AddMonths((int)direction);
+
+            // If no budget exists yet for that month
+            if (false == App.GlobalBudget.BudgetMonthExistByMonthYear(destMonth))
+            {
+                // create the budget for that month
+                // (copy the goal from the current month)
+                var copiedGoal = App.GlobalBudget.GetBudgetGoalByMonthYear(
+                    App.GlobalViewData.CurrentlyDisplayedMonthYear);
+                App.GlobalBudget.CreateNewMonth(copiedGoal, destMonth);
+            }
+
+            // Now that we know that a budget exists for the month that we are going to
+            // Set the currently displayed month to be the destination month
+            App.GlobalViewData.CurrentlyDisplayedMonthYear = destMonth;
+        }
+
+        //// For testing purposes only
+        //public static void UpdateGoal(decimal newGoal)
+        //{
+        //    App.GlobalBudget.GetBudgetMonthByMonthYear(
+        //        App.GlobalViewData.CurrentlyDisplayedMonthYear).BudgetGoal = newGoal;
+
+        //}
+
+
+
+        //// Expense Categories only exposed to the View here for purpose of
+        //// demoing to Andrea for Add/Edit expense
+        //public ReadOnlyCollection<ExpenseCategory> ExpenseCategories
+        //{
+        //    get
+        //    {
+        //        return ExpenseCategoryManager.Collection;
+        //    }
+        //}
 
 
 

--- a/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
+++ b/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
@@ -14,6 +14,14 @@ namespace MadMoney.ViewModel
         
         }
 
+        public string MonthYear_ForCurrentlyShownMonth_String
+        {
+            get
+            {
+                return App.GlobalViewData.CurrentlyDisplayedMonthYear.ToString("MMMM yyyy");
+            }
+        }
+
         public decimal BudgetGoal_ForCurrentlyShownMonth_Decimal
         {
             get

--- a/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
+++ b/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
@@ -14,15 +14,66 @@ namespace MadMoney.ViewModel
         
         }
 
-        public decimal BudgetGoal
+        public decimal BudgetGoal_ForCurrentlyShownMonth_Decimal
         {
             get
             {
-                return App.GlobalBudget.GetBudgetGoalByMonthYear(App.GlobalViewData.CurrentlyDisplayedMonthYear);
+                return App.GlobalBudget.GetBudgetGoalByMonthYear(
+                               App.GlobalViewData.CurrentlyDisplayedMonthYear);
             }
 
         }
 
+        public string BudgetGoal_ForCurrentlyShownMonth_String
+        {
+            get
+            {
+                return BudgetGoal_ForCurrentlyShownMonth_Decimal.ToString("N2");
+            }
+        }
+
+        public decimal TotalExpenses_ForCurrentlyShownMonth_Decimal
+        {
+            get
+            {
+                var expenses = App.GlobalBudget.GetExpensesByMonthYear(
+                            App.GlobalViewData.CurrentlyDisplayedMonthYear);
+
+                // Sum in LINQ with a selector:
+                // https://www.csharp-examples.net/linq-sum/
+                return expenses.ToList().Sum(expense => expense.Amount);
+            }
+        }
+
+        public string TotalExpenses_ForCurrentlyShownMonth_String
+        {
+            get
+            {
+                return TotalExpenses_ForCurrentlyShownMonth_Decimal.ToString("N2");
+            }
+        }
+
+        // Delta between the user's specified budget goal for the month and the
+        // current total of expenses for the month
+        public decimal BudgetRemaining_ForCurrentlyShownMonth_Decimal
+        {
+            get
+            {
+                return BudgetGoal_ForCurrentlyShownMonth_Decimal - TotalExpenses_ForCurrentlyShownMonth_Decimal;
+            }
+        }
+
+        public string BudgetRemaining_ForCurrentlyShownMonth_String
+        {
+            get
+            {
+                return BudgetRemaining_ForCurrentlyShownMonth_Decimal.ToString("N2");
+            }
+        }
+
+
+
+        // Expense Categories only exposed to the View here for purpose of demoing to Andrea for Add/Edit expense
         public ReadOnlyCollection<ExpenseCategory> ExpenseCategories
         {
             get

--- a/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
+++ b/MadMoney/MadMoney/ViewModel/MainBudgetSummaryPageViewModel.cs
@@ -101,17 +101,22 @@ namespace MadMoney.ViewModel
 
 
 
-        //public IEnumerable<Expense> Expenses
-        //{
-        //    get
-        //    {
-        //        return App.GlobalBudget.GetBudgetMonthByMonthYear(;
-        //    }
-        //}
+        // Ideally, the ViewModel would do string formatting for the View for expenses
+        // I think this would involve programmatically configuring the ItemTemplate,
+        // DataTemplate, or ViewCell of the ListView
+        // For now, setting the formatting directly in the XAML
+        public IEnumerable<Expense> Expenses
+        {
+            get
+            {
+                return App.GlobalBudget.GetBudgetMonthByMonthYear(
+                            App.GlobalViewData.CurrentlyDisplayedMonthYear).Expenses;
+            }
+        }
 
 
 
-        
+
 
 
     }


### PR DESCRIPTION
Previous and Next month buttons now work and create adjacent month budgets as needed
Expense amount now formatted properly in the expenses ListView. Matches formatting of the currency amounts at the top of the page.
Correct emoji is shown for each expense in the main page expenses ListView
Date is string formatted from the XAML
Main page header now correctly shows the current month and year
Budget goal, budget remaining and total expenses properties queried from the back end, calculated and served to the view as formatted strings.