### PR TITLE
Brillan main page for edit expense

### DIFF
--- a/MadMoney/MadMoney/EditExpense.xaml.cs
+++ b/MadMoney/MadMoney/EditExpense.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MadMoney.Model;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,10 +13,23 @@ namespace MadMoney
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class EditExpense : ContentPage
     {
-        public EditExpense()
+        private string idOfExpenseToEdit;
+
+        public EditExpense(string expenseId)
         {
+            idOfExpenseToEdit = expenseId;
+
+            // Looking up the expense here to prove that looking it up works
+            // View should pass the id to a method on the viewmodel,
+            // then the viewmodel should look up the expense and implement
+            // the properties that the view will bind to
+            var copyOfExpenseToEdit =
+                App.GlobalBudget.GetCopyOfExpenseById(idOfExpenseToEdit);
+
             InitializeComponent();
         }
+
+
 
         private void OnCancelButton_Clicked(object sender, EventArgs e)
         {
@@ -25,11 +39,22 @@ namespace MadMoney
         private void OnSaveButton_Clicked(object sender, EventArgs e)
         {
 
+
+
         }
 
         private void OnDeleteButton_Clicked(object sender, EventArgs e)
         {
+            // Migrate all of this method (except for the Navigation call)
+            // to the corresponding method on the EditExpense viewmodel class
+            bool expenseDeleted = App.GlobalBudget.DeleteExpenseById(idOfExpenseToEdit);
+            if (false == expenseDeleted)
+            {
+                throw new ArgumentException(
+                    $"Could not delete expense with Id {idOfExpenseToEdit}.");
+            }
 
+            Navigation.PopAsync();
         }
     }
 }

--- a/MadMoney/MadMoney/MadMoney.csproj
+++ b/MadMoney/MadMoney/MadMoney.csproj
@@ -15,7 +15,11 @@
     <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
   </ItemGroup>
 
-
+  <ItemGroup>
+    <Reference Include="Mono.Android">
+      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v9.0\Mono.Android.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Update="MainBudgetSummaryPage.xaml.cs">

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
@@ -7,6 +7,25 @@
              x:Class="MadMoney.MainBudgetSummaryPage"
              xmlns:data="MadMoney.Model">
 
+    
+    <!-- Defining some styles to make it easier to change font size
+         across multiple UI controls at once. -->
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <!-- Goal, Remaining and Total -->
+            <Style x:Key="MainLabelFontSize" TargetType="Label">
+                <Setter Property="FontSize" Value="Large" />
+            </Style>
+            <!-- All of the expense properites in the ListView -->
+            <Style x:Key="ListViewFontSize" TargetType="Label">
+                <Setter Property="FontSize" Value="15" />
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    
+    
+    
+    
     <StackLayout>
 
         <StackLayout x:Name="MonthNavigationBar"
@@ -32,45 +51,57 @@
 
         <StackLayout Orientation="Horizontal">
 
-            <Label Text="Budget Goal:"/>
+            <Label Text="Budget Goal:"
+                   Style="{StaticResource MainLabelFontSize}"/>
             <!-- TODO: Fix this empty Label hack for 
                                 I can't figure out how else to do the left
                                 and right justify -->
             <Label HorizontalOptions="CenterAndExpand"/>
-            <Label Text="💲"/>
+            <Label Text="💲"
+                   Style="{StaticResource MainLabelFontSize}"/>
             <Label x:Name="BudgetGoalText"
-                   Text="{Binding BudgetGoal_ForCurrentlyShownMonth_String}"/>
-            <Label Text="🖍️"/>
+                   Text="{Binding BudgetGoal_ForCurrentlyShownMonth_String}"
+                   Style="{StaticResource MainLabelFontSize}"/>
+            <Label Text="🏁"
+                   Style="{StaticResource MainLabelFontSize}"/>
 
         </StackLayout>
 
         <StackLayout Orientation="Horizontal">
 
-            <Label Text="Budget Remaining:"/>
+            <Label Text="Budget Remaining:"
+                   Style="{StaticResource MainLabelFontSize}"/>
             <!-- TODO: Fix this empty Label hack for 
                                 I can't figure out how else to do the left
                                 and right justify -->
             <Label HorizontalOptions="CenterAndExpand"/>
-            <Label Text="💲"/>
+            <Label Text="💲"
+                   Style="{StaticResource MainLabelFontSize}"/>
             <Label x:Name="BudgetRemainingText"
-                   Text="{Binding BudgetRemaining_ForCurrentlyShownMonth_String}"/>
+                   Text="{Binding BudgetRemaining_ForCurrentlyShownMonth_String}"
+                   Style="{StaticResource MainLabelFontSize}"/>
             <!-- TODO: Update color/icon to reflect whether the user is below,
             at, or beyond their budget goal. -->
-            <Label Text="🆗"/>
+            <Label Text="🆗"
+                   Style="{StaticResource MainLabelFontSize}"/>
 
         </StackLayout>
 
         <StackLayout Orientation="Horizontal">
 
-            <Label Text="Total Expenses:"/>
+            <Label Text="Total Expenses:"
+                   Style="{StaticResource MainLabelFontSize}"/>
             <!-- TODO: Fix this empty Label hack for 
                                 I can't figure out how else to do the left
                                 and right justify -->
             <Label HorizontalOptions="CenterAndExpand"/>
-            <Label Text="💲"/>
+            <Label Text="💲"
+                   Style="{StaticResource MainLabelFontSize}"/>
             <Label x:Name="TotalExpensesText"
-                   Text="{Binding TotalExpenses_ForCurrentlyShownMonth_String}"/>
-            <Label Text="💸"/>
+                   Text="{Binding TotalExpenses_ForCurrentlyShownMonth_String}"
+                   Style="{StaticResource MainLabelFontSize}"/>
+            <Label Text="💸"
+                   Style="{StaticResource MainLabelFontSize}"/>
 
         </StackLayout>
 
@@ -120,22 +151,27 @@
                         <ViewCell>
                             <StackLayout>
                                 <StackLayout Orientation="Horizontal">
-                                    <Label Text="{Binding Description}"/>
+                                    <Label Text="{Binding Description}"
+                                           Style="{StaticResource ListViewFontSize}"/>
                                     <!-- TODO: Fix this empty Label hack for 
                                     I can't figure out how else to do the left
                                     and right justify -->
                                     <Label HorizontalOptions="CenterAndExpand"/>
-                                    <Label Text="{Binding Category.Emoji}"/>
+                                    <Label Text="{Binding Category.Emoji}"
+                                           Style="{StaticResource ListViewFontSize}"/>
                                     <!-- TODO: Update once emoji conversions are in -->
                                 </StackLayout>
                                 <StackLayout Orientation="Horizontal">
-                                    <Label Text="{Binding Date, StringFormat='{0:MM/dd/yyyy}'}"/>
+                                    <Label Text="{Binding Date, StringFormat='{0:MM/dd/yyyy}'}"
+                                           Style="{StaticResource ListViewFontSize}"/>
                                     <!-- TODO: Fix this empty Label hack for 
                                     I can't figure out how else to do the left
                                     and right justify -->
                                     <Label HorizontalOptions="CenterAndExpand"/>
-                                    <Label Text="💲"/>
-                                    <Label Text="{Binding Amount, StringFormat='{0:N2}'}"/>
+                                    <Label Text="💲"
+                                           Style="{StaticResource ListViewFontSize}"/>
+                                    <Label Text="{Binding Amount, StringFormat='{0:N2}'}"
+                                           Style="{StaticResource ListViewFontSize}"/>
                                 </StackLayout>
                             </StackLayout>
                         </ViewCell>

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml
@@ -113,7 +113,7 @@
                 Text="Add Expense"
                 FontSize="16"
                 BackgroundColor="LightGreen"
-                Clicked="AddExpenseButton_Top_Clicked"/>
+                Pressed="AddExpenseButton_Top_Pressed"/>
             <!-- TODO: Fix this empty Label hack for 
                                 I can't figure out how else to do the left
                                 and right justify -->
@@ -145,7 +145,8 @@
                     Also on ListView: ItemsSource="{Binding expenseCollection}"
                     Currently setting BindingContext instead in MainBudgetSummaryPage constructor -->
             <ListView x:Name="ExpensesListView"
-                      ItemsSource="{Binding Expenses}">
+                      ItemsSource="{Binding Expenses}"
+                      ItemTapped="ExpensesListView_ItemTapped">
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <ViewCell>
@@ -192,16 +193,5 @@
 
     </StackLayout>
 
-
-    <!--
-
-    <StackLayout>
-
-        <Label Text="Welcome to Xamarin.Forms!" 
-           HorizontalOptions="Center"
-           VerticalOptions="CenterAndExpand" />
-    </StackLayout>
-    
-    -->
 
 </ContentPage>

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -13,7 +13,10 @@ namespace MadMoney
     [DesignTimeVisible(false)]
     public partial class MainBudgetSummaryPage : ContentPage
     {
-        // May not need to retain a reference to the ViewModel instance
+        // Storage for the viewmodel object
+        // Doing this instead of (MainBudgetSummaryPageViewModel)BindingContext
+        // for readability since we will need a temp var for it eventually
+        // anyway in OnAppearing
         private MainBudgetSummaryPageViewModel ViewModel = null;
 
         public MainBudgetSummaryPage()
@@ -49,8 +52,9 @@ namespace MadMoney
                             ExpenseCategory.Enum.Healthcare);
 
 
-            // May not need to retain a reference to the ViewModel instance
-            BindingContext = ViewModel = new MainBudgetSummaryPageViewModel();
+            // Save reference to the viewmodel instance
+            // will remove it and re-add it OnAppearing
+            ViewModel = new MainBudgetSummaryPageViewModel();
 
 
 
@@ -63,15 +67,25 @@ namespace MadMoney
         }
 
 
-        private void PreviousMonthButton_Pressed(object sender, EventArgs e)
+        // Whenever this page is loaded, and also every time this page is
+        // navigated to from another page (such as when a page above it on
+        // the stack is popped)
+        protected override void OnAppearing()
         {
-            ViewModel.LoadPreviousMonth();
+            base.OnAppearing();
+            ResetBindingContext();
+        }
+
+        private void ResetBindingContext()
+        {
 
             // Clear the BindingContext for the MainPage, then set it back to
             // the same ViewModel. Goal is to force the UI to re-query all
             // the properties that it is bound to on the viewmodel.
+
             BindingContext = null;
             BindingContext = ViewModel;
+
             // For some reason setting it to null is required, doesn't work
             // without that. I wonder why!
             // Perhaps the compiler optimizes away the re-assignment of ViewModel
@@ -81,12 +95,21 @@ namespace MadMoney
             // be static after all. Whoops! I'll attribute that design oversight
             // to me being new to using properties on classes.
 
-
             // TODO: OBSERVE AND VERIFY
             // (Does that work for getting all of the UI elements to refresh?)
             // Yes, it does.
             // Probably still the best practice to navigate back to the main
             // (That is, the MainPage navigating to itself)
+
+        }
+
+
+
+        private void PreviousMonthButton_Pressed(object sender, EventArgs e)
+        {
+            ViewModel.LoadPreviousMonth();
+
+            ResetBindingContext();
 
             // See also:
             // Budget.AddExpense() for another place that is currently
@@ -105,26 +128,8 @@ namespace MadMoney
         {
             ViewModel.LoadNextMonth();
 
-            // Clear the BindingContext for the MainPage, then set it back to
-            // the same ViewModel. Goal is to force the UI to re-query all
-            // the properties that it is bound to on the viewmodel.
-            BindingContext = null;
-            BindingContext = ViewModel;
-            // For some reason setting it to null is required, doesn't work
-            // without that. I wonder why!
-            // Perhaps the compiler optimizes away the re-assignment of ViewModel
-            // to BindingContext, as though it could not possibly have an effect?
-            // This viewmodel class type, while instantiable, has no state.
-            // Wait. If the class type truly has no state, it should probably
-            // be static after all. Whoops! I'll attribute that design oversight
-            // to me being new to using properties on classes.
 
-
-            // TODO: OBSERVE AND VERIFY
-            // (Does that work for getting all of the UI elements to refresh?)
-            // Yes, it does.
-            // Probably still the best practice to navigate back to the main
-            // (That is, the MainPage navigating to itself)
+            ResetBindingContext();
 
             // See also:
             // Budget.AddExpense() for another place that is currently

--- a/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
+++ b/MadMoney/MadMoney/MainBudgetSummaryPage.xaml.cs
@@ -174,9 +174,18 @@ namespace MadMoney
             Navigation.PushAsync(new AddExpense());
         }
 
+
+
+        private void ExpensesListView_ItemTapped(object sender, ItemTappedEventArgs e)
+        {
+            var tappedExpense = (Expense)e.Item;
+
+            Navigation.PushAsync(new EditExpense(tappedExpense.Id));
+        }
+
         private void ExpensesListView_ItemSelected(object sender, SelectedItemChangedEventArgs e)
         {
-            Navigation.PushAsync(new EditExpense());
+
         }
 
         // Retained because there is some reference to this in the solution somewhere
@@ -184,5 +193,7 @@ namespace MadMoney
         {
 
         }
+
+
     }
 }

--- a/MadMoney/MadMoney/Model/Budget.cs
+++ b/MadMoney/MadMoney/Model/Budget.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using MadMoney.Utility;
 
@@ -118,6 +119,69 @@ namespace MadMoney.Model
             budgetMonthOfExpense.AddExpense(new Expense(expDescrip, expAmt, expDate, expCat));
 
         }
+
+        // Returns null if no expense could be found with the specified Id
+        public Expense GetCopyOfExpenseById(string id)
+        {
+            var foundExpense = FindExpenseById(id);
+
+            // If we found a match
+            if (null != foundExpense)
+            {
+                // Return a copy of it
+                // Note that this copies the Id
+                // (a new Id is NOT generated)
+                return new Expense(foundExpense.Id,
+                                   foundExpense.Description,
+                                   foundExpense.Amount,
+                                   foundExpense.Date,
+                                   foundExpense.Category);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private Expense FindExpenseById(string Id)
+        {
+            Expense foundExpense = null;
+
+            foreach (var month in budgetMonths)
+            {
+                foundExpense = month.Expenses.ToList().Find(expense => expense.Id == Id);
+                if (null != foundExpense)
+                {
+                    // If we find an expense that matches the parameter Id
+                    // stop looking through the budget months
+                    break;
+                }
+            }
+
+            return (null != foundExpense) ? foundExpense : null;
+        }
+
+
+
+        // Returns true if expense was found and deleted
+        // Returns false if expense was not found (no expense was deleted)
+        public bool DeleteExpenseById(string id)
+        {
+            bool deletedExpense = false;
+
+            foreach (var month in budgetMonths)
+            {
+                deletedExpense = month.DeleteExpense(id);
+
+                if (true == deletedExpense)
+                {
+                    break;
+                }
+            }
+
+            return deletedExpense ? true : false;
+        }
+
 
         // The design doesn't provide for deleting a budget month
         // public void DeleteBudget(DateTime month) { }

--- a/MadMoney/MadMoney/Model/BudgetMonth.cs
+++ b/MadMoney/MadMoney/Model/BudgetMonth.cs
@@ -86,8 +86,23 @@ namespace MadMoney.Model
         // How to specify which Expense to edit?
         // How to submit those edits?
 
-        public void DeleteExpense(string id) { }
-        // How to specify which Expense to delete?
+
+
+        // No protection for the bad state of multiple expenses erroneously
+        // having the same Id. The first (and hopefully only) match
+        // will be deleted.
+        public bool DeleteExpense(string id)
+        {
+            var foundExpense =
+                expenseCollection.Find(expense => expense.Id == id);
+
+            // For a reference type T, the Remove method on List<T> checks
+            // for reference equality, that is, it checks to see if the
+            // object parameter is literally the same object in memory as
+            // the object in the list.
+            return expenseCollection.Remove(foundExpense);
+        }
+
 
 
         // View should ask ViewModel to ask Model about

--- a/MadMoney/MadMoney/Model/ExpenseCategory.cs
+++ b/MadMoney/MadMoney/Model/ExpenseCategory.cs
@@ -57,6 +57,7 @@ namespace MadMoney.Model
         }
 
 
+
         public Enum Id { get; set; }
 
         public string Emoji


### PR DESCRIPTION
Started EditExpense page:
Accept the id of the expense to be edited as a constructor parameter
Event handler for delete button (body to be refactored into a viewmodel method)

Budget and BudgetMonth now support deleting an expense
Budget will return a copy of an expense given a specified id
Reset the BindingContext in OnAppearing on the main page (refreshes all data bindings)
Static resource styles for main page XAML (font size)